### PR TITLE
[git] Put protocol for cmake submodule to https instead of git.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Dear Joseph,
This pull request is to fix a small problem regarding the protocol used in the cmake submodule